### PR TITLE
add doc values blocks compressed

### DIFF
--- a/gradle/testing/randomization/policies/tests.policy
+++ b/gradle/testing/randomization/policies/tests.policy
@@ -97,6 +97,8 @@ grant {
   permission java.io.FilePermission "${hunspell.corpora}${/}-", "read";
   permission java.io.FilePermission "${hunspell.dictionaries}", "read";
   permission java.io.FilePermission "${hunspell.dictionaries}${/}-", "read";
+
+  permission java.lang.RuntimePermission "loadLibrary.*";
 };
 
 // Permissions to support ant build

--- a/lucene/core/build.gradle
+++ b/lucene/core/build.gradle
@@ -20,6 +20,7 @@ apply plugin: 'java-library'
 description = 'Lucene core library'
 
 dependencies {
+  implementation group: 'com.github.luben', name: 'zstd-jni', version: '1.4.9-5'
   testImplementation project(':lucene:codecs')
   testImplementation project(':lucene:test-framework')
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
@@ -21,10 +21,6 @@ import org.apache.lucene.store.DataOutput;
 
 import java.io.IOException;
 
-/**
- * @author weizijun.wzj
- * @date 2021/8/18
- */
 public interface BaseEncoder {
     void add(int index, long value);
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
@@ -16,40 +16,41 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
+import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 
-import java.io.IOException;
-
-/**
- * doc values block encoder
- */
+/** doc values block encoder */
 public interface BaseEncoder {
-    /**
-     * add a value
-     * @param index the value's index
-     * @param value the value
-     */
-    void add(int index, long value);
+  /**
+   * add a value
+   *
+   * @param index the value's index
+   * @param value the value
+   */
+  void add(int index, long value);
 
-    /**
-     * encode buffer data to output
-     * @param out data output
-     * @throws IOException if io exception
-     */
-    void encode(DataOutput out) throws IOException;
+  /**
+   * encode buffer data to output
+   *
+   * @param out data output
+   * @throws IOException if io exception
+   */
+  void encode(DataOutput out) throws IOException;
 
-    /**
-     * get a value
-     * @param index the value's index
-     * @return the value of index
-     */
-    long get(int index);
+  /**
+   * get a value
+   *
+   * @param index the value's index
+   * @return the value of index
+   */
+  long get(int index);
 
-    /**
-     * decode input data to buffer
-     * @param in data input
-     * @throws IOException if io exception
-     */
-    void decode(DataInput in) throws IOException;
+  /**
+   * decode input data to buffer
+   *
+   * @param in data input
+   * @throws IOException if io exception
+   */
+  void decode(DataInput in) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
@@ -21,12 +21,35 @@ import org.apache.lucene.store.DataOutput;
 
 import java.io.IOException;
 
+/**
+ * doc values block encoder
+ */
 public interface BaseEncoder {
+    /**
+     * add a value
+     * @param index
+     * @param value
+     */
     void add(int index, long value);
 
+    /**
+     * encode buffer data to output
+     * @param out data output
+     * @throws IOException if io exception
+     */
     void encode(DataOutput out) throws IOException;
 
+    /**
+     * get a value
+     * @param index the value's index
+     * @return the value of index
+     */
     long get(int index);
 
+    /**
+     * decode input data to buffer
+     * @param in data input
+     * @throws IOException if io exception
+     */
     void decode(DataInput in) throws IOException;
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+import java.io.IOException;
+
+/**
+ * @author weizijun.wzj
+ * @date 2021/8/18
+ */
+public interface BaseEncoder {
+    void add(int index, long value);
+
+    void encode(DataOutput out) throws IOException;
+
+    long get(int index);
+
+    void decode(DataInput in) throws IOException;
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/BaseEncoder.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 public interface BaseEncoder {
     /**
      * add a value
-     * @param index
-     * @param value
+     * @param index the value's index
+     * @param value the value
      */
     void add(int index, long value);
 

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeltaLZ4DocValuesEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DeltaLZ4DocValuesEncoder.java
@@ -16,74 +16,77 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
+import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.compress.LZ4;
 
-import java.io.IOException;
-
-/**
- * first use delta encode, then compressed.
- */
+/** first use delta encode, then compressed. */
 public class DeltaLZ4DocValuesEncoder implements BaseEncoder {
 
-    static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
-    private LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
+  static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
+  private LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
 
-    private final byte[] buffer = new byte[BLOCK_SIZE * Long.BYTES];
-    private final long[] longs = new long[BLOCK_SIZE];
+  private final byte[] buffer = new byte[BLOCK_SIZE * Long.BYTES];
+  private final long[] longs = new long[BLOCK_SIZE];
 
-    @Override
-    public void add(int index, long value) {
-        assert index < BLOCK_SIZE;
-        longs[index] = value;
+  @Override
+  public void add(int index, long value) {
+    assert index < BLOCK_SIZE;
+    longs[index] = value;
+  }
+
+  private void writeLong(int index, long value) {
+    int pos = index * Long.BYTES;
+    writeInt(pos, (int) (value >> 32));
+    writeInt(pos + 4, (int) value);
+  }
+
+  private void writeInt(int index, int value) {
+    buffer[index] = (byte) (value >> 24);
+    buffer[index + 1] = (byte) (value >> 16);
+    buffer[index + 2] = (byte) (value >> 8);
+    buffer[index + 3] = (byte) value;
+  }
+
+  @Override
+  public void encode(DataOutput out) throws IOException {
+    long preValue = 0;
+    for (int i = 0; i < longs.length; ++i) {
+      writeLong(i, longs[i] - preValue);
+      preValue = longs[i];
     }
+    LZ4.compress(buffer, 0, buffer.length, out, ht);
+  }
 
-    private void writeLong(int index, long value) {
-        int pos = index * Long.BYTES;
-        writeInt(pos, (int) (value >> 32));
-        writeInt(pos + 4, (int) value);
-    }
+  @Override
+  public long get(int index) {
+    return longs[index];
+  }
 
-    private void writeInt(int index, int value) {
-        buffer[index] = (byte) (value >> 24);
-        buffer[index + 1] = (byte) (value >> 16);
-        buffer[index + 2] = (byte) (value >> 8);
-        buffer[index + 3] = (byte) value;
-    }
+  private long readLong(int index) {
+    int id = index * Long.BYTES;
+    final int i1 =
+        ((buffer[id] & 0xff) << 24)
+            | ((buffer[id + 1] & 0xff) << 16)
+            | ((buffer[id + 2] & 0xff) << 8)
+            | (buffer[id + 3] & 0xff);
+    final int i2 =
+        ((buffer[id + 4] & 0xff) << 24)
+            | ((buffer[id + 5] & 0xff) << 16)
+            | ((buffer[id + 6] & 0xff) << 8)
+            | (buffer[id + 7] & 0xff);
+    return (((long) i1) << 32) | (i2 & 0xFFFFFFFFL);
+  }
 
-    @Override
-    public void encode(DataOutput out) throws IOException {
-        long preValue = 0;
-        for (int i = 0; i < longs.length; ++i) {
-            writeLong(i, longs[i] - preValue);
-            preValue = longs[i];
-        }
-        LZ4.compress(buffer, 0, buffer.length, out, ht);
+  @Override
+  public void decode(DataInput in) throws IOException {
+    LZ4.decompress(in, buffer.length, buffer, 0);
+    long preValue = 0;
+    for (int i = 0; i < buffer.length / Long.BYTES; i++) {
+      long value = readLong(i) + preValue;
+      longs[i] = value;
+      preValue = value;
     }
-
-    @Override
-    public long get(int index) {
-        return longs[index];
-    }
-
-    private long readLong(int index) {
-        int id = index * Long.BYTES;
-        final int i1 = ((buffer[id] & 0xff) << 24) | ((buffer[id + 1] & 0xff) << 16) | ((buffer[id + 2]
-                & 0xff) << 8) | (buffer[id + 3] & 0xff);
-        final int i2 = ((buffer[id + 4] & 0xff) << 24) | ((buffer[id + 5] & 0xff) << 16) | ((buffer[id
-                + 6] & 0xff) << 8) | (buffer[id + 7] & 0xff);
-        return (((long) i1) << 32) | (i2 & 0xFFFFFFFFL);
-    }
-
-    @Override
-    public void decode(DataInput in) throws IOException {
-        LZ4.decompress(in, buffer.length, buffer, 0);
-        long preValue = 0;
-        for (int i = 0; i < buffer.length / Long.BYTES; i++) {
-            long value = readLong(i) + preValue;
-            longs[i] = value;
-            preValue = value;
-        }
-    }
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DocValuesEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/DocValuesEncoder.java
@@ -27,7 +27,7 @@ import org.apache.lucene.util.packed.PackedInts;
  * Encoder for blocks of doc values. This automatically detects whether values are monotonic or have
  * a common divisor to decide on a good compression strategy.
  */
-final class DocValuesEncoder {
+final class DocValuesEncoder implements BaseEncoder {
 
   static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
 
@@ -209,5 +209,29 @@ final class DocValuesEncoder {
     for (int i = 1; i < BLOCK_SIZE; ++i) {
       arr[i] += arr[i - 1];
     }
+  }
+
+  private final long[] buffer = new long[BLOCK_SIZE];
+
+  @Override
+  public void add(int index, long value) {
+    assert index < BLOCK_SIZE;
+    buffer[index] = value;
+  }
+
+  @Override
+  public void encode(DataOutput out) throws IOException {
+    encode(buffer, out);
+  }
+
+  @Override
+  public long get(int index) {
+    assert index < BLOCK_SIZE;
+    return buffer[index];
+  }
+
+  @Override
+  public void decode(DataInput in) throws IOException {
+    decode(in, buffer);
   }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4DocValuesEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4DocValuesEncoder.java
@@ -16,54 +16,57 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
+import java.io.IOException;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.DataOutput;
 import org.apache.lucene.util.compress.LZ4;
 
-import java.io.IOException;
-
-/**
- * Compressed blocks of doc values.
- */
+/** Compressed blocks of doc values. */
 public class LZ4DocValuesEncoder implements BaseEncoder {
 
-    static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
-    private LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
+  static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
+  private LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
 
-    private final byte[] buffer = new byte[BLOCK_SIZE * Long.BYTES];
+  private final byte[] buffer = new byte[BLOCK_SIZE * Long.BYTES];
 
-    @Override
-    public void add(int index, long value) {
-        assert index < BLOCK_SIZE;
-        int pos = index * Long.BYTES;
-        writeInt(pos, (int) (value >> 32));
-        writeInt(pos + 4, (int) value);
-    }
+  @Override
+  public void add(int index, long value) {
+    assert index < BLOCK_SIZE;
+    int pos = index * Long.BYTES;
+    writeInt(pos, (int) (value >> 32));
+    writeInt(pos + 4, (int) value);
+  }
 
-    private void writeInt(int index, int value) {
-        buffer[index] = (byte) (value >> 24);
-        buffer[index + 1] = (byte) (value >> 16);
-        buffer[index + 2] = (byte) (value >> 8);
-        buffer[index + 3] = (byte) value;
-    }
+  private void writeInt(int index, int value) {
+    buffer[index] = (byte) (value >> 24);
+    buffer[index + 1] = (byte) (value >> 16);
+    buffer[index + 2] = (byte) (value >> 8);
+    buffer[index + 3] = (byte) value;
+  }
 
-    @Override
-    public void encode(DataOutput out) throws IOException {
-        LZ4.compress(buffer, 0, buffer.length, out, ht);
-    }
+  @Override
+  public void encode(DataOutput out) throws IOException {
+    LZ4.compress(buffer, 0, buffer.length, out, ht);
+  }
 
-    @Override
-    public long get(int index) {
-        int id = index * Long.BYTES;
-        final int i1 = ((buffer[id] & 0xff) << 24) | ((buffer[id + 1] & 0xff) << 16) | ((buffer[id + 2]
-                & 0xff) << 8) | (buffer[id + 3] & 0xff);
-        final int i2 = ((buffer[id + 4] & 0xff) << 24) | ((buffer[id + 5] & 0xff) << 16) | ((buffer[id
-                + 6] & 0xff) << 8) | (buffer[id + 7] & 0xff);
-        return (((long) i1) << 32) | (i2 & 0xFFFFFFFFL);
-    }
+  @Override
+  public long get(int index) {
+    int id = index * Long.BYTES;
+    final int i1 =
+        ((buffer[id] & 0xff) << 24)
+            | ((buffer[id + 1] & 0xff) << 16)
+            | ((buffer[id + 2] & 0xff) << 8)
+            | (buffer[id + 3] & 0xff);
+    final int i2 =
+        ((buffer[id + 4] & 0xff) << 24)
+            | ((buffer[id + 5] & 0xff) << 16)
+            | ((buffer[id + 6] & 0xff) << 8)
+            | (buffer[id + 7] & 0xff);
+    return (((long) i1) << 32) | (i2 & 0xFFFFFFFFL);
+  }
 
-    @Override
-    public void decode(DataInput in) throws IOException {
-        LZ4.decompress(in, buffer.length, buffer, 0);
-    }
+  @Override
+  public void decode(DataInput in) throws IOException {
+    LZ4.decompress(in, buffer.length, buffer, 0);
+  }
 }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4DocValuesEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/LZ4DocValuesEncoder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90;
+
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+import org.apache.lucene.util.compress.LZ4;
+
+import java.io.IOException;
+
+/**
+ * Compressed blocks of doc values.
+ */
+public class LZ4DocValuesEncoder implements BaseEncoder {
+
+    static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
+    private LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
+
+    private final byte[] buffer = new byte[BLOCK_SIZE * Long.SIZE];
+
+    @Override
+    public void add(int index, long value) {
+        assert index < BLOCK_SIZE;
+        int pos = index * Long.BYTES;
+        writeInt(pos, (int) (value >> 32));
+        writeInt(pos + 4, (int) value);
+    }
+
+    private void writeInt(int index, int value) {
+        buffer[index] = (byte) (value >> 24);
+        buffer[index + 1] = (byte) (value >> 16);
+        buffer[index + 2] = (byte) (value >> 8);
+        buffer[index + 3] = (byte) value;
+    }
+
+    @Override
+    public void encode(DataOutput out) throws IOException {
+        LZ4.compress(buffer, 0, buffer.length, out, ht);
+    }
+
+    @Override
+    public long get(int index) {
+        int id = index * Long.BYTES;
+        final int i1 = ((buffer[id] & 0xff) << 24) | ((buffer[id + 1] & 0xff) << 16) | ((buffer[id + 2]
+                & 0xff) << 8) | (buffer[id + 3] & 0xff);
+        final int i2 = ((buffer[id + 4] & 0xff) << 24) | ((buffer[id + 5] & 0xff) << 16) | ((buffer[id
+                + 6] & 0xff) << 8) | (buffer[id + 7] & 0xff);
+        return (((long) i1) << 32) | (i2 & 0xFFFFFFFFL);
+    }
+
+    @Override
+    public void decode(DataInput in) throws IOException {
+        LZ4.decompress(in, buffer.length, buffer, 0);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -184,7 +184,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
 
       // TODO select a encoder
       // final DocValuesEncoder encoder = new DocValuesEncoder();
-      final BaseEncoder encoder = new LZ4DocValuesEncoder();
+      final BaseEncoder encoder = new ZstdDocValuesEncoder();
       values = valuesProducer.getSortedNumeric(field);
       for (int doc = values.nextDoc();
           doc != DocIdSetIterator.NO_MORE_DOCS;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -183,7 +183,7 @@ final class Lucene90DocValuesConsumer extends DocValuesConsumer {
       final long valuesDataOffset = data.getFilePointer();
 
       // TODO select a encoder
-      //final DocValuesEncoder encoder = new DocValuesEncoder();
+      // final DocValuesEncoder encoder = new DocValuesEncoder();
       final BaseEncoder encoder = new LZ4DocValuesEncoder();
       values = valuesProducer.getSortedNumeric(field);
       for (int doc = values.nextDoc();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesConsumer.java
@@ -21,7 +21,6 @@ import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.NUMERIC_
 import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
 
 import java.io.IOException;
-import java.util.Arrays;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.DocValuesConsumer;
 import org.apache.lucene.codecs.DocValuesProducer;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -18,7 +18,6 @@ package org.apache.lucene.codecs.lucene90;
 
 import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.NUMERIC_BLOCK_MASK;
 import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.NUMERIC_BLOCK_SHIFT;
-import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
 import static org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SHIFT;
 
 import java.io.IOException;

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -435,9 +435,10 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
     final IndexInput valuesData = data.slice("values", entry.valuesOffset, entry.valuesLength);
     return new NumericValues() {
 
-      private final DocValuesEncoder decoder = new DocValuesEncoder();
+      // TODO select a encoder
+      // private final DocValuesEncoder decoder = new DocValuesEncoder();
+      private final BaseEncoder decoder = new LZ4DocValuesEncoder();
       private long currentBlockIndex = -1;
-      private final long[] currentBlock = new long[NUMERIC_BLOCK_SIZE];
 
       @Override
       long advance(long index) throws IOException {
@@ -449,9 +450,9 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
             valuesData.seek(indexReader.get(blockIndex));
           }
           currentBlockIndex = blockIndex;
-          decoder.decode(valuesData, currentBlock);
+          decoder.decode(valuesData);
         }
-        return currentBlock[blockInIndex];
+        return decoder.get(blockInIndex);
       }
     };
   }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90DocValuesProducer.java
@@ -436,7 +436,7 @@ final class Lucene90DocValuesProducer extends DocValuesProducer {
 
       // TODO select a encoder
       // private final DocValuesEncoder decoder = new DocValuesEncoder();
-      private final BaseEncoder decoder = new LZ4DocValuesEncoder();
+      private final BaseEncoder decoder = new ZstdDocValuesEncoder();
       private long currentBlockIndex = -1;
 
       @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/ZstdDocValuesEncoder.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/ZstdDocValuesEncoder.java
@@ -1,0 +1,60 @@
+package org.apache.lucene.codecs.lucene90;
+
+import com.github.luben.zstd.Zstd;
+import org.apache.lucene.store.DataInput;
+import org.apache.lucene.store.DataOutput;
+
+import java.io.IOException;
+
+/** Compressed blocks of doc values. */
+public class ZstdDocValuesEncoder implements BaseEncoder {
+
+    static final int BLOCK_SIZE = Lucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
+    private final byte[] buffer = new byte[BLOCK_SIZE * Long.BYTES];
+    private final byte[] compressBlock = new byte[(int) Zstd.compressBound(BLOCK_SIZE * Long.BYTES)];
+
+    @Override
+    public void add(int index, long value) {
+        assert index < BLOCK_SIZE;
+        int pos = index * Long.BYTES;
+        writeInt(pos, (int) (value >> 32));
+        writeInt(pos + 4, (int) value);
+    }
+
+    private void writeInt(int index, int value) {
+        buffer[index] = (byte) (value >> 24);
+        buffer[index + 1] = (byte) (value >> 16);
+        buffer[index + 2] = (byte) (value >> 8);
+        buffer[index + 3] = (byte) value;
+    }
+
+    @Override
+    public void encode(DataOutput out) throws IOException {
+        int compressLength = ZstdUtil.compress(compressBlock, 0, compressBlock.length, buffer, 0, buffer.length, 1);
+        out.writeVInt(compressLength);
+        out.writeBytes(compressBlock, compressLength);
+    }
+
+    @Override
+    public long get(int index) {
+        int id = index * Long.BYTES;
+        final int i1 =
+                ((buffer[id] & 0xff) << 24)
+                        | ((buffer[id + 1] & 0xff) << 16)
+                        | ((buffer[id + 2] & 0xff) << 8)
+                        | (buffer[id + 3] & 0xff);
+        final int i2 =
+                ((buffer[id + 4] & 0xff) << 24)
+                        | ((buffer[id + 5] & 0xff) << 16)
+                        | ((buffer[id + 6] & 0xff) << 8)
+                        | (buffer[id + 7] & 0xff);
+        return (((long) i1) << 32) | (i2 & 0xFFFFFFFFL);
+    }
+
+    @Override
+    public void decode(DataInput in) throws IOException {
+        int compressedBlockLength = in.readVInt();
+        in.readBytes(compressBlock, 0, compressedBlockLength);
+        ZstdUtil.decompress(buffer, 0, buffer.length, compressBlock, 0, compressedBlockLength);
+    }
+}

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/ZstdUtil.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/ZstdUtil.java
@@ -1,0 +1,26 @@
+package org.apache.lucene.codecs.lucene90;
+
+import com.github.luben.zstd.ZstdCompressCtx;
+import com.github.luben.zstd.ZstdDecompressCtx;
+import com.github.luben.zstd.ZstdException;
+
+public class ZstdUtil {
+    public static int compress(byte[] dstBuff, int dstOffset, int dstSize, byte[] srcBuff, int srcOffset, int srcSize, int level) {
+        ZstdCompressCtx ctx = new ZstdCompressCtx();
+        try {
+            ctx.setLevel(level);
+            return ctx.compressByteArray(dstBuff, dstOffset, dstSize, srcBuff, srcOffset, srcSize);
+        } finally {
+            ctx.close();
+        }
+    }
+
+    public static int decompress(byte[] dstBuff, int dstOffset, int dstSize, byte[] srcBuff, int srcOffset, int srcSize) throws ZstdException {
+        ZstdDecompressCtx ctx = new ZstdDecompressCtx();
+        try {
+            return ctx.decompressByteArray(dstBuff, dstOffset, dstSize, srcBuff, srcOffset, srcSize);
+        } finally {
+            ctx.close();
+        }
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDeltaLZ4DocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDeltaLZ4DocValuesEncoder.java
@@ -16,77 +16,75 @@
  */
 package org.apache.lucene.codecs.lucene90;
 
-
+import java.io.IOException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.LuceneTestCase;
 
-import java.io.IOException;
-
 public class TestDeltaLZ4DocValuesEncoder extends LuceneTestCase {
-    public void testRandomValues() throws IOException {
-        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
-        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
-            arr[i] = random().nextLong();
-        }
-        doTest(arr, -1);
+  public void testRandomValues() throws IOException {
+    long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+      arr[i] = random().nextLong();
     }
+    doTest(arr, -1);
+  }
 
-    public void testDeltaOverflowValues() throws IOException {
-        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
-        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
-            if (i % 2 == 0) {
-                arr[i] = Long.MIN_VALUE + random().nextInt(10000);
-            } else {
-                arr[i] = Long.MAX_VALUE - random().nextInt(10000);
-            }
-        }
-        doTest(arr, -1);
+  public void testDeltaOverflowValues() throws IOException {
+    long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+      if (i % 2 == 0) {
+        arr[i] = Long.MIN_VALUE + random().nextInt(10000);
+      } else {
+        arr[i] = Long.MAX_VALUE - random().nextInt(10000);
+      }
     }
+    doTest(arr, -1);
+  }
 
-    public void testIncreasingValues() throws IOException {
-        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
-        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
-            arr[i] = 30 * i - 1000;
-        }
-        long expectedNumBytes = 28;
-        doTest(arr, expectedNumBytes);
+  public void testIncreasingValues() throws IOException {
+    long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+      arr[i] = 30 * i - 1000;
     }
+    long expectedNumBytes = 28;
+    doTest(arr, expectedNumBytes);
+  }
 
-    public void testDecreasingValues() throws IOException {
-        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
-        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
-            arr[i] = 1000 - 30 * i;
-        }
-        long expectedNumBytes = 28;
-        doTest(arr, expectedNumBytes);
+  public void testDecreasingValues() throws IOException {
+    long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+      arr[i] = 1000 - 30 * i;
     }
+    long expectedNumBytes = 28;
+    doTest(arr, expectedNumBytes);
+  }
 
-    private void doTest(long[] arr, long expectedNumBytes) throws IOException {
-        final long[] expected = arr.clone();
-        DeltaLZ4DocValuesEncoder encoder = new DeltaLZ4DocValuesEncoder();
+  private void doTest(long[] arr, long expectedNumBytes) throws IOException {
+    final long[] expected = arr.clone();
+    DeltaLZ4DocValuesEncoder encoder = new DeltaLZ4DocValuesEncoder();
+    for (int i = 0; i < expected.length; i++) {
+      encoder.add(i, expected[i]);
+    }
+    try (Directory dir = newDirectory()) {
+      try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+        encoder.encode(out);
+        if (expectedNumBytes != -1) {
+          assertEquals(expectedNumBytes, out.getFilePointer());
+        }
+      }
+      try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+        encoder.decode(in);
+        assertEquals(in.length(), in.getFilePointer());
+
+        long[] decoded = new long[expected.length];
         for (int i = 0; i < expected.length; i++) {
-            encoder.add(i, expected[i]);
+          decoded[i] = encoder.get(i);
         }
-        try (Directory dir = newDirectory()) {
-            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
-                encoder.encode(out);
-                if (expectedNumBytes != -1) {
-                    assertEquals(expectedNumBytes, out.getFilePointer());
-                }
-            }
-            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
-                encoder.decode(in);
-                assertEquals(in.length(), in.getFilePointer());
-
-                long[] decoded = new long[expected.length];
-                for (int i = 0; i < expected.length; i++) {
-                    decoded[i] = encoder.get(i);
-                }
-                assertArrayEquals(expected, decoded);
-            }
-        }
+        assertArrayEquals(expected, decoded);
+      }
     }
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDeltaLZ4DocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDeltaLZ4DocValuesEncoder.java
@@ -22,6 +22,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.NumericUtils;
 
 public class TestDeltaLZ4DocValuesEncoder extends LuceneTestCase {
   public void testRandomValues() throws IOException {
@@ -59,6 +60,27 @@ public class TestDeltaLZ4DocValuesEncoder extends LuceneTestCase {
       arr[i] = 1000 - 30 * i;
     }
     long expectedNumBytes = 28;
+    doTest(arr, expectedNumBytes);
+  }
+
+  public void testTimeSeries() throws IOException {
+    long[] arr = new long[DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(1.1);
+    }
+
+    for (int i = DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE / 2; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(2.2);
+    }
+
+    for (int i = DocValuesEncoder.BLOCK_SIZE / 2; i < 3 * DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(3.3);
+    }
+
+    for (int i = 3 * DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(4.4);
+    }
+    final long expectedNumBytes = 49;
     doTest(arr, expectedNumBytes);
   }
 

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDeltaLZ4DocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDeltaLZ4DocValuesEncoder.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90;
+
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.LuceneTestCase;
+
+import java.io.IOException;
+
+public class TestDeltaLZ4DocValuesEncoder extends LuceneTestCase {
+    public void testRandomValues() throws IOException {
+        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+            arr[i] = random().nextLong();
+        }
+        doTest(arr, -1);
+    }
+
+    public void testDeltaOverflowValues() throws IOException {
+        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+            if (i % 2 == 0) {
+                arr[i] = Long.MIN_VALUE + random().nextInt(10000);
+            } else {
+                arr[i] = Long.MAX_VALUE - random().nextInt(10000);
+            }
+        }
+        doTest(arr, -1);
+    }
+
+    public void testIncreasingValues() throws IOException {
+        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+            arr[i] = 30 * i - 1000;
+        }
+        long expectedNumBytes = 28;
+        doTest(arr, expectedNumBytes);
+    }
+
+    public void testDecreasingValues() throws IOException {
+        long[] arr = new long[DeltaLZ4DocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < DeltaLZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+            arr[i] = 1000 - 30 * i;
+        }
+        long expectedNumBytes = 28;
+        doTest(arr, expectedNumBytes);
+    }
+
+    private void doTest(long[] arr, long expectedNumBytes) throws IOException {
+        final long[] expected = arr.clone();
+        DeltaLZ4DocValuesEncoder encoder = new DeltaLZ4DocValuesEncoder();
+        for (int i = 0; i < expected.length; i++) {
+            encoder.add(i, expected[i]);
+        }
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+                encoder.encode(out);
+                if (expectedNumBytes != -1) {
+                    assertEquals(expectedNumBytes, out.getFilePointer());
+                }
+            }
+            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+                encoder.decode(in);
+                assertEquals(in.length(), in.getFilePointer());
+
+                long[] decoded = new long[expected.length];
+                for (int i = 0; i < expected.length; i++) {
+                    decoded[i] = encoder.get(i);
+                }
+                assertArrayEquals(expected, decoded);
+            }
+        }
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestDocValuesEncoder.java
@@ -143,6 +143,27 @@ public class TestDocValuesEncoder extends LuceneTestCase {
     doTest(arr, expectedNumBytes);
   }
 
+  public void testTimeSeries() throws IOException {
+    long[] arr = new long[DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(1.1);
+    }
+
+    for (int i = DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE / 2; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(2.2);
+    }
+
+    for (int i = DocValuesEncoder.BLOCK_SIZE / 2; i < 3 * DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(3.3);
+    }
+
+    for (int i = 3 * DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(4.4);
+    }
+    final long expectedNumBytes = 1036;
+    doTest(arr, expectedNumBytes);
+  }
+
   private void doTest(long[] arr, long expectedNumBytes) throws IOException {
     final long[] expected = arr.clone();
     DocValuesEncoder encoder = new DocValuesEncoder();

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLZ4DocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLZ4DocValuesEncoder.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.codecs.lucene90;
+
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.LuceneTestCase;
+
+import java.io.IOException;
+
+public class TestLZ4DocValuesEncoder extends LuceneTestCase {
+    public void testRandomValues() throws IOException {
+        long[] arr = new long[LZ4DocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < LZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
+            arr[i] = random().nextLong();
+        }
+        doTest(arr);
+    }
+
+    private void doTest(long[] arr) throws IOException {
+        final long[] expected = arr.clone();
+        LZ4DocValuesEncoder encoder = new LZ4DocValuesEncoder();
+        for (int i = 0; i < expected.length; i++) {
+            encoder.add(i, expected[i]);
+        }
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+                encoder.encode(out);
+            }
+            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+                encoder.decode(in);
+                assertEquals(in.length(), in.getFilePointer());
+
+                long[] decoded = new long[expected.length];
+                for (int i = 0; i < expected.length; i++) {
+                    decoded[i] = encoder.get(i);
+                }
+                assertArrayEquals(expected, decoded);
+            }
+        }
+    }
+}

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLZ4DocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestLZ4DocValuesEncoder.java
@@ -22,6 +22,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.NumericUtils;
 
 public class TestLZ4DocValuesEncoder extends LuceneTestCase {
   public void testRandomValues() throws IOException {
@@ -29,10 +30,31 @@ public class TestLZ4DocValuesEncoder extends LuceneTestCase {
     for (int i = 0; i < LZ4DocValuesEncoder.BLOCK_SIZE; ++i) {
       arr[i] = random().nextLong();
     }
-    doTest(arr);
+    doTest(arr, -1);
   }
 
-  private void doTest(long[] arr) throws IOException {
+  public void testTimeSeries() throws IOException {
+    long[] arr = new long[DocValuesEncoder.BLOCK_SIZE];
+    for (int i = 0; i < DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(1.1);
+    }
+
+    for (int i = DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE / 2; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(2.2);
+    }
+
+    for (int i = DocValuesEncoder.BLOCK_SIZE / 2; i < 3 * DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(3.3);
+    }
+
+    for (int i = 3 * DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE; i++) {
+      arr[i] = NumericUtils.doubleToSortableLong(4.4);
+    }
+    final long expectedNumBytes = 46;
+    doTest(arr, expectedNumBytes);
+  }
+
+  private void doTest(long[] arr, long expectedNumBytes) throws IOException {
     final long[] expected = arr.clone();
     LZ4DocValuesEncoder encoder = new LZ4DocValuesEncoder();
     for (int i = 0; i < expected.length; i++) {
@@ -41,6 +63,9 @@ public class TestLZ4DocValuesEncoder extends LuceneTestCase {
     try (Directory dir = newDirectory()) {
       try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
         encoder.encode(out);
+        if (expectedNumBytes != -1) {
+          assertEquals(expectedNumBytes, out.getFilePointer());
+        }
       }
       try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
         encoder.decode(in);

--- a/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestZstdDocValuesEncoder.java
+++ b/lucene/core/src/test/org/apache/lucene/codecs/lucene90/TestZstdDocValuesEncoder.java
@@ -1,0 +1,67 @@
+package org.apache.lucene.codecs.lucene90;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.LuceneTestCase;
+import org.apache.lucene.util.NumericUtils;
+
+import java.io.IOException;
+
+public class TestZstdDocValuesEncoder extends LuceneTestCase {
+    public void testRandomValues() throws IOException {
+        long[] arr = new long[ZstdDocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < ZstdDocValuesEncoder.BLOCK_SIZE; ++i) {
+            arr[i] = random().nextLong();
+        }
+        doTest(arr, -1);
+    }
+
+    public void testTimeSeries() throws IOException {
+        long[] arr = new long[DocValuesEncoder.BLOCK_SIZE];
+        for (int i = 0; i < DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+            arr[i] = NumericUtils.doubleToSortableLong(1.1);
+        }
+
+        for (int i = DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE / 2; i++) {
+            arr[i] = NumericUtils.doubleToSortableLong(2.2);
+        }
+
+        for (int i = DocValuesEncoder.BLOCK_SIZE / 2; i < 3 * DocValuesEncoder.BLOCK_SIZE / 4; i++) {
+            arr[i] = NumericUtils.doubleToSortableLong(3.3);
+        }
+
+        for (int i = 3 * DocValuesEncoder.BLOCK_SIZE / 4; i < DocValuesEncoder.BLOCK_SIZE; i++) {
+            arr[i] = NumericUtils.doubleToSortableLong(4.4);
+        }
+        final long expectedNumBytes = 47;
+        doTest(arr, expectedNumBytes);
+    }
+
+    private void doTest(long[] arr, long expectedNumBytes) throws IOException {
+        final long[] expected = arr.clone();
+        ZstdDocValuesEncoder encoder = new ZstdDocValuesEncoder();
+        for (int i = 0; i < expected.length; i++) {
+            encoder.add(i, expected[i]);
+        }
+        try (Directory dir = newDirectory()) {
+            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+                encoder.encode(out);
+                if (expectedNumBytes != -1) {
+                    assertEquals(expectedNumBytes, out.getFilePointer());
+                }
+            }
+            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+                encoder.decode(in);
+                assertEquals(in.length(), in.getFilePointer());
+
+                long[] decoded = new long[expected.length];
+                for (int i = 0; i < expected.length; i++) {
+                    decoded[i] = encoder.get(i);
+                }
+                assertArrayEquals(expected, decoded);
+            }
+        }
+    }
+}


### PR DESCRIPTION
hi, @jpountz ,  I add two dv blocks encoder. One is lz4 compress encoder, another is delta and lz4 compress encoder.
we tests in our time series case, it has a good compression ratio. and the speed is almost the same as not encode.
we can test in luceneutil later.

And, I think the dv encoder can use in keyword's ord data, I can push a commit to add this feature.